### PR TITLE
API additions and other stuff (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `StableVec::into_vec()`
 - `impl<T> Default for StableVec<T>`
 - Added `FromIterator` impl for `StableVec`
+- Added `Extend` impl for `StableVec`
 - Added `Debug` impl for `StableVec` with a fitting example
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `StableVec::contains()`
 - `StableVec::into_vec()`
 - `StableVec::retain()`
+- `StableVec::stable_compact()`
 - `StableVec::keys()` with `Keys` iterator
 - `IterMut::remove_current()`
 - `impl<T> Default for StableVec<T>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added method overview in documentation
 - `StableVec::contains()`
+- `impl<T> Default for StableVec<T>`
 
 
 ## [0.1.2] - 2017-09-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Renamed `compact()` to `reordering_make_compact()`: changing element order by
   default is a bad idea. Instead `make_compact()` should be used to preserve
   order.
+- Renamed `exists()` to `has_element_at()`
 
 ## [0.1.2] - 2017-09-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `StableVec::contains()`
 - `StableVec::into_vec()`
 - `impl<T> Default for StableVec<T>`
+- Added `FromIterator` impl for `StableVec`
 - Added `Debug` impl for `StableVec` with a fitting example
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added method overview in documentation
 - `StableVec::contains()`
+- `StableVec::into_vec()`
 - `impl<T> Default for StableVec<T>`
 - Added `Debug` impl for `StableVec` with a fitting example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `StableVec::contains()`
 - `StableVec::into_vec()`
 - `StableVec::keys()` with `Keys` iterator
+- `IterMut::remove_current()`
 - `impl<T> Default for StableVec<T>`
 - Added `FromIterator` impl for `StableVec`
 - Added `Extend` impl for `StableVec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added method overview in documentation
+
 
 ## [0.1.2] - 2017-09-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added method overview in documentation
 - `StableVec::contains()`
 - `StableVec::into_vec()`
+- `StableVec::keys()` with `Keys` iterator
 - `impl<T> Default for StableVec<T>`
 - Added `FromIterator` impl for `StableVec`
 - Added `Extend` impl for `StableVec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `FromIterator` impl for `StableVec`
 - Added `Extend` impl for `StableVec`
 - Added `Debug` impl for `StableVec` with a fitting example
+- Added `PartialEq` impls to compare a `StableVec` with slices and `Vec`s
 
 
 ## [0.1.2] - 2017-09-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `StableVec::contains()`
 - `StableVec::into_vec()`
 - `StableVec::retain()`
-- `StableVec::stable_compact()`
+- `StableVec::make_compact()`
 - `StableVec::keys()` with `Keys` iterator
 - `IterMut::remove_current()`
 - `impl<T> Default for StableVec<T>`
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `Debug` impl for `StableVec` with a fitting example
 - Added `PartialEq` impls to compare a `StableVec` with slices and `Vec`s
 
+### Changed
+- Renamed `compact()` to `reordering_make_compact()`: changing element order by
+  default is a bad idea. Instead `make_compact()` should be used to preserve
+  order.
 
 ## [0.1.2] - 2017-09-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added method overview in documentation
+- `StableVec::contains()`
 
 
 ## [0.1.2] - 2017-09-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added method overview in documentation
 - `StableVec::contains()`
 - `impl<T> Default for StableVec<T>`
+- Added `Debug` impl for `StableVec` with a fitting example
 
 
 ## [0.1.2] - 2017-09-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2017-09-17
 ### Added
 - Added method overview in documentation
 - `StableVec::contains()`
@@ -30,7 +32,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Travis-CI badge entry in `Cargo.toml`
 - Warning in example
 
-
 ## [0.1.1] - 2017-09-15
 ### Added
 - Added this `CHANGELOG.md`
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Everything.
 
 
-[Unreleased]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.2.0...HEAD
+[0.2.ß]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added method overview in documentation
 - `StableVec::contains()`
 - `StableVec::into_vec()`
+- `StableVec::retain()`
 - `StableVec::keys()` with `Keys` iterator
 - `IterMut::remove_current()`
 - `impl<T> Default for StableVec<T>`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-vec"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 
 description = """

--- a/examples/compact.rs
+++ b/examples/compact.rs
@@ -25,7 +25,7 @@ fn main() {
 
     let n_before_compact = sv.num_elements();
 
-    sv.compact();
+    sv.make_compact();
     println!("--- after compact():");
     for i in 0..sv.next_index() {
         println!("{} -> {:?}", i, sv.get(i));

--- a/examples/iterators.rs
+++ b/examples/iterators.rs
@@ -23,4 +23,8 @@ fn main() {
     for e in &sv {
         println!("{:?}", e);
     }
+
+    // StableVec implements `FromIterator`
+    let sv: StableVec<_> = (1..9).collect();
+    println!("{:?}", sv);
 }

--- a/examples/printing.rs
+++ b/examples/printing.rs
@@ -1,0 +1,15 @@
+extern crate stable_vec;
+
+use stable_vec::StableVec;
+
+fn main() {
+    let mut sv = StableVec::from(&['a', 'b', 'c', 'd', 'e', 'f']);
+    println!("{:?}", sv);
+
+    sv.remove(1);
+    sv.remove(4);
+    println!("{:?}", sv);
+
+    sv.push('x');
+    println!("{:?}", sv);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! stable_vec = "0.1"
+//! stable_vec = "0.2"
 //! ```
 //!
 //! ... as well as declare it at your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,7 +557,7 @@ impl<T> StableVec<T> {
     ///     *e *= 2.0;
     /// }
     ///
-    /// assert_eq!(sv.into_vec(), vec![2.0, 4.0, 6.0]);
+    /// assert_eq!(sv, &[2.0, 4.0, 6.0] as &[_]);
     /// ```
     ///
     /// As mentioned above, you can remove elements from the stable vector
@@ -577,7 +577,7 @@ impl<T> StableVec<T> {
     ///     }
     /// }
     ///
-    /// assert_eq!(sv.into_vec(), vec![2.0, 6.0]);
+    /// assert_eq!(sv, &[2.0, 6.0] as &[_]);
     /// ```
     pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut {
@@ -909,5 +909,34 @@ impl<T: fmt::Debug> fmt::Debug for StableVec<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "StableVec ")?;
         f.debug_list().entries(self).finish()
+    }
+}
+
+impl<A, B> PartialEq<[B]> for StableVec<A>
+    where A: PartialEq<B>,
+{
+    fn eq(&self, other: &[B]) -> bool {
+        for (i, e) in self.iter().enumerate() {
+            if e != &other[i] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<'other, A, B> PartialEq<&'other [B]> for StableVec<A>
+    where A: PartialEq<B>,
+{
+    fn eq(&self, other: & &'other [B]) -> bool {
+        self == *other
+    }
+}
+
+impl<A, B> PartialEq<Vec<B>> for StableVec<A>
+    where A: PartialEq<B>,
+{
+    fn eq(&self, other: &Vec<B>) -> bool {
+        self == &other[..]
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,10 +138,11 @@ mod tests;
 ///
 /// **Stable vector specific**
 ///
-/// - [`exists()`](#method.exists)
-/// - [`compact()`](#method.compact)
-/// - [`is_compact()`](#method.is_compact)
+/// - [`has_element_at()`](#method.has_element_at)
 /// - [`next_index()`](#method.next_index)
+/// - [`is_compact()`](#method.is_compact)
+/// - [`make_compact()`](#method.make_compact)
+/// - [`reordering_make_compact()`](#method.reordering_make_compact)
 ///
 /// **Number of elements**
 ///
@@ -246,8 +247,9 @@ impl<T> StableVec<T> {
         self.remove(last_index)
     }
 
-    /// Removes and returns the element at position `index` if there
-    /// [`exists()`](#method.exists) an element at that index.
+    /// Removes and returns the element at position `index` if there exists an
+    /// element at that index (as defined by
+    /// [`has_element_at()`](#method.has_element_at)).
     ///
     /// Removing an element only marks it as "deleted" without touching the
     /// actual data. In particular, the elements after the given index are
@@ -271,7 +273,7 @@ impl<T> StableVec<T> {
     /// assert_eq!(sv.remove(heart_idx), None); // the heart was already removed
     /// ```
     pub fn remove(&mut self, index: usize) -> Option<T> {
-        if self.exists(index) {
+        if self.has_element_at(index) {
             // We move the requested element out of our `data` vector. Usually,
             // it's impossible to move out of a vector without removing the
             // element in the vector. We can achieve it by using unsafe code:
@@ -296,7 +298,7 @@ impl<T> StableVec<T> {
     /// If you are calling `unwrap()` on the result of this method anyway,
     /// rather use the index operator instead: `stable_vec[index]`.
     pub fn get(&self, index: usize) -> Option<&T> {
-        if self.exists(index) {
+        if self.has_element_at(index) {
             Some(&self.data[index])
         } else {
             None
@@ -309,7 +311,7 @@ impl<T> StableVec<T> {
     /// If you are calling `unwrap()` on the result of this method anyway,
     /// rather use the index operator instead: `stable_vec[index]`.
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
-        if self.exists(index) {
+        if self.has_element_at(index) {
             Some(&mut self.data[index])
         } else {
             None
@@ -327,15 +329,15 @@ impl<T> StableVec<T> {
     /// ```
     /// # use stable_vec::StableVec;
     /// let mut sv = StableVec::new();
-    /// assert!(!sv.exists(3));         // no: index out of bounds
+    /// assert!(!sv.has_element_at(3));         // no: index out of bounds
     ///
     /// let heart_idx = sv.push('♥');
-    /// assert!(sv.exists(heart_idx));  // yes
+    /// assert!(sv.has_element_at(heart_idx));  // yes
     ///
     /// sv.remove(heart_idx);
-    /// assert!(!sv.exists(heart_idx)); // no: was removed
+    /// assert!(!sv.has_element_at(heart_idx)); // no: was removed
     /// ```
-    pub fn exists(&self, index: usize) -> bool {
+    pub fn has_element_at(&self, index: usize) -> bool {
         index < self.data.len() && !self.deleted[index]
     }
 
@@ -799,7 +801,7 @@ impl<T> Index<usize> for StableVec<T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &T {
-        assert!(self.exists(index));
+        assert!(self.has_element_at(index));
 
         &self.data[index]
     }
@@ -807,7 +809,7 @@ impl<T> Index<usize> for StableVec<T> {
 
 impl<T> IndexMut<usize> for StableVec<T> {
     fn index_mut(&mut self, index: usize) -> &mut T {
-        assert!(self.exists(index));
+        assert!(self.has_element_at(index));
 
         &mut self.data[index]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,6 +683,31 @@ impl<T> StableVec<T> {
         // with an empty vector. After this line, `self` is dropped.
         mem::replace(&mut self.data, Vec::new())
     }
+
+    /// Retains only the elements specified by the given predicate.
+    ///
+    /// Each element `e` for which `predicate(&e)` returns `false` is removed
+    /// from the stable vector.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use stable_vec::StableVec;
+    /// let mut sv = StableVec::from(&[1, 2, 3, 4, 5]);
+    /// sv.retain(|&e| e % 2 == 0);
+    ///
+    /// assert_eq!(sv, &[2, 4] as &[_]);
+    /// ```
+    pub fn retain<P>(&mut self, mut predicate: P)
+        where P: FnMut(&T) -> bool,
+    {
+        let mut it = self.iter_mut();
+        while let Some(e) = it.next() {
+            if !predicate(e) {
+                it.remove_current();
+            }
+        }
+    }
 }
 
 impl<T> Drop for StableVec<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern crate quickcheck;
 
 use bit_vec::BitVec;
 
+use std::fmt;
 use std::ops::{Index, IndexMut};
 use std::ptr;
 
@@ -710,5 +711,12 @@ impl<'a, T> Iterator for IterMut<'a, T> {
             self.pos += 1;
             self.vec_iter.next()
         }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for StableVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "StableVec ")?;
+        f.debug_list().entries(self).finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,6 +611,12 @@ impl<T> IndexMut<usize> for StableVec<T> {
     }
 }
 
+impl<T> Default for StableVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T, S> From<S> for StableVec<T>
     where S: AsRef<[T]>,
           T: Clone

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,8 @@ mod tests;
 ///
 /// # Method overview
 ///
+/// (*there are more methods than mentioned in this overview*)
+///
 /// **Associated functions**
 ///
 /// - [`new()`](#method.new)
@@ -131,7 +133,7 @@ mod tests;
 /// - [the mutable `[]` index operator](#impl-IndexMut<usize>) (returns `&mut T`)
 /// - [`remove()`](#method.remove) (returns `Option<T>`)
 ///
-/// **Stable vec specific**
+/// **Stable vector specific**
 ///
 /// - [`exists()`](#method.exists)
 /// - [`compact()`](#method.compact)
@@ -541,6 +543,28 @@ impl<T> StableVec<T> {
             vec_iter: self.data.iter_mut(),
             pos: 0,
         }
+    }
+
+    /// Returns `true` if the stable vector contains an element with the given
+    /// value, `false` otherwise.
+    ///
+    /// ```
+    /// # use stable_vec::StableVec;
+    /// let mut sv = StableVec::from(&['a', 'b', 'c']);
+    /// assert!(sv.contains(&'b'));
+    ///
+    /// sv.remove(1);   // 'b' is stored at index 1
+    /// assert!(!sv.contains(&'b'));
+    /// ```
+    pub fn contains<U>(&self, item: &U) -> bool
+        where U: PartialEq<T>
+    {
+        for e in self {
+            if item == e {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -739,7 +739,7 @@ impl<T> StableVec<T> {
         self.used_count = 0;
         self.deleted.truncate(0);
 
-        // The `data` vector is moved out of this data structureand replaced
+        // The `data` vector is moved out of this data structure and replaced
         // with an empty vector. After this line, `self` is dropped.
         mem::replace(&mut self.data, Vec::new())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,18 +351,24 @@ impl<T> StableVec<T> {
         self.data.shrink_to_fit();
     }
 
-    /// Rearranges elements to reclaim memory. **Invalidates indices!**
+    /// Rearranges elements to reclaim memory. **Invalidates indices and
+    /// changes the order of the elements!**
     ///
     /// After calling this method, all existing elements stored contiguously
     /// in memory. You might want to call [`shrink_to_fit()`](#method.shrink_to_fit)
     /// afterwards to actually free memory previously used by removed elements.
     /// This method itself does not deallocate any memory.
     ///
+    /// If you do need to preserve the order of elements, use
+    /// [`make_compact()`](#method.make_compact) instead. However, if you don't
+    /// care about element order, you should prefer using this method, because
+    /// it is faster.
+    ///
     /// # Warning
     ///
-    /// This method invalidates all indices! It does not even preserve the
-    /// order of elements.
-    pub fn compact(&mut self) {
+    /// This method invalidates all indices and it does not preserve the order
+    /// of elements!
+    pub fn reordering_make_compact(&mut self) {
         if self.is_compact() {
             return;
         }
@@ -425,7 +431,7 @@ impl<T> StableVec<T> {
     /// # Warning
     ///
     /// This method invalidates all indices!
-    pub fn stable_compact(&mut self) {
+    pub fn make_compact(&mut self) {
         if self.is_compact() {
             return;
         }
@@ -703,18 +709,16 @@ impl<T> StableVec<T> {
     ///
     /// Returns a vector which contains all existing elements from this stable
     /// vector. **All indices might be invalidated!** This method might call
-    /// [`compact()`](#method.compact); see that method's documentation to
-    /// learn about the effects on indices.
+    /// [`make_compact()`](#method.make_compact); see that method's
+    /// documentation to learn about the effects on indices.
     ///
     /// This method does not allocate memory.
-    ///
     ///
     /// # Note
     ///
     /// If the stable vector is not compact (as defined by `is_compact()`), the
-    /// runtime complexity of this function is O(n), because `compact()` needs
-    /// to be called.
-    ///
+    /// runtime complexity of this function is O(n), because `make_compact()`
+    /// needs to be called.
     ///
     /// # Example
     ///
@@ -727,7 +731,7 @@ impl<T> StableVec<T> {
     /// ```
     pub fn into_vec(mut self) -> Vec<T> {
         // Compact the stable vec to prepare the `data` vector for moving.
-        self.compact();
+        self.make_compact();
 
         // We reset all values to the "empty state" here. This is necessary to
         // make sure the `drop()` impl doesn't do anything (except for actually

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ impl<T> StableVec<T> {
     /// `Vec<T>` that holds the actual data.
     ///
     /// If you want to compact this `StableVec` by removing deleted elements,
-    /// use the method [`compact()`](#method.compact) instead.
+    /// use the method [`make_compact()`](#method.make_compact) instead.
     pub fn shrink_to_fit(&mut self) {
         self.data.shrink_to_fit();
     }
@@ -360,8 +360,10 @@ impl<T> StableVec<T> {
     /// afterwards to actually free memory previously used by removed elements.
     /// This method itself does not deallocate any memory.
     ///
-    /// In comparison to [`compact()`](#method.compact), this method does not
-    /// change the order of elements. Due to this, this method is a bit slower.
+    /// In comparison to
+    /// [`reordering_make_compact()`](#method.reordering_make_compact), this
+    /// method does not change the order of elements. Due to this, this method
+    /// is a bit slower.
     ///
     /// # Warning
     ///
@@ -500,7 +502,7 @@ impl<T> StableVec<T> {
     ///
     /// As long as `remove()` is never called, `num_elements()` equals
     /// `next_index()`. Once it is called, `num_elements()` will always be less
-    /// than `next_index()` (assuming `compact()` is not called).
+    /// than `next_index()` (assuming `make_compact()` is not called).
     ///
     /// # Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate quickcheck;
 use bit_vec::BitVec;
 
 use std::fmt;
+use std::iter::FromIterator;
 use std::mem;
 use std::ops::{Index, IndexMut};
 use std::ptr;
@@ -670,6 +671,19 @@ impl<T, S> From<S> for StableVec<T>
             data: slice.as_ref().into(),
             deleted: BitVec::from_elem(len, false),
             used_count: len,
+        }
+    }
+}
+
+impl<T> FromIterator<T> for StableVec<T> {
+    fn from_iter<I>(iter: I) -> Self
+        where I: IntoIterator<Item = T>
+    {
+        let data = Vec::from_iter(iter);
+        Self {
+            used_count: data.len(),
+            deleted: BitVec::from_elem(data.len(), false),
+            data,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! This crate provides a simple stable vector implementation. You can find
 //! nearly all the relevant documentation on
-//! [this crate's only type: `StableVec`](struct.StableVec.html).
+//! [the type `StableVec`](struct.StableVec.html).
 //!
 //! ---
 //!
@@ -108,6 +108,47 @@ mod tests;
 /// please consult [the official `Vec<T>` documentation][vec-doc] first.
 ///
 /// [vec-doc]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
+///
+///
+/// # Method overview
+///
+/// **Associated functions**
+///
+/// - [`new()`](#method.new)
+/// - [`with_capacity()`](#method.with_capacity())
+///
+/// **Adding and removing elements**
+///
+/// - [`push()`](#method.push)
+/// - [`pop()`](#method.pop)
+/// - [`remove()`](#method.remove)
+///
+/// **Accessing elements**
+///
+/// - [`get()`](#method.get) (returns `Option<&T>`)
+/// - [the `[]` index operator](#impl-Index<usize>) (returns `&T`)
+/// - [`get_mut()`](#method.get_mut) (returns `Option<&mut T>`)
+/// - [the mutable `[]` index operator](#impl-IndexMut<usize>) (returns `&mut T`)
+/// - [`remove()`](#method.remove) (returns `Option<T>`)
+///
+/// **Stable vec specific**
+///
+/// - [`exists()`](#method.exists)
+/// - [`compact()`](#method.compact)
+/// - [`is_compact()`](#method.is_compact)
+/// - [`next_index()`](#method.next_index)
+///
+/// **Number of elements**
+///
+/// - [`is_empty()`](#method.is_empty)
+/// - [`num_elements()`](#method.num_elements)
+///
+/// **Capacity management**
+///
+/// - [`capacity()`](#method.capacity)
+/// - [`shrink_to_fit()`](#method.shrink_to_fit)
+/// - [`reserve()`](#method.reserve)
+///
 #[derive(Clone, PartialEq, Eq)]
 pub struct StableVec<T> {
     /// Storing the actual data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,63 @@ impl<T> StableVec<T> {
         }
 
         // We can safely call `set_len()` here: all elements that still need
-        // to be dropped are in the range 0..self.used_count + 1.
+        // to be dropped are in the range 0..self.used_count.
+        unsafe {
+            self.data.set_len(self.used_count);
+            self.deleted.set_len(self.used_count);
+        }
+    }
+
+    /// Rearranges elements to reclaim memory. **Invalidates indices!**
+    ///
+    /// After calling this method, all existing elements stored contiguously
+    /// in memory. You might want to call [`shrink_to_fit()`](#method.shrink_to_fit)
+    /// afterwards to actually free memory previously used by removed elements.
+    /// This method itself does not deallocate any memory.
+    ///
+    /// In comparison to [`compact()`](#method.compact), this method does not
+    /// change the order of elements. Due to this, this method is a bit slower.
+    ///
+    /// # Warning
+    ///
+    /// This method invalidates all indices!
+    pub fn stable_compact(&mut self) {
+        if self.is_compact() {
+            return;
+        }
+
+        // We only have to move elements, if we have any.
+        if self.used_count > 0 {
+            // We have to find the position of the first hole. We know that
+            // there is at least one hole, so we can unwrap.
+            let first_hole_index = self.deleted.iter().position(|d| d).unwrap();
+
+            // This variable will store the first possible index of an element
+            // which can be inserted in the hole.
+            let mut element_index = first_hole_index + 1;
+
+            // Beginning from the first hole, we have to fill each index with
+            // a new value. This is required to keep the order of elements.
+            for hole_index in first_hole_index..self.used_count {
+                // Actually find the next element which we can use to fill the
+                // hole. Note that we do not check if `element_index` runs out
+                // of bounds. This will never happen! We do have enough
+                // elements to fill all holes. And once all holes are filled,
+                // the outer loop will stop.
+                while self.deleted[element_index] {
+                    element_index += 1;
+                }
+
+                // So at this point `hole_index` points to a valid hole and
+                // `element_index` points to a valid element. Time to swap!
+                self.data.swap(hole_index, element_index);
+                self.deleted.set(hole_index, false);
+                self.deleted.set(element_index, true);
+            }
+        }
+
+        // We can safely call `set_len()` here: all elements that still need
+        // to be dropped are in the range 0..self.used_count.
         unsafe {
             self.data.set_len(self.used_count);
             self.deleted.set_len(self.used_count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,8 @@ impl<T> StableVec<T> {
     ///
     /// # Warning
     ///
-    /// This method invalidates all indices!
+    /// This method invalidates the indices of all elements that are stored
+    /// after the first hole in the stable vector!
     pub fn make_compact(&mut self) {
         if self.is_compact() {
             return;
@@ -426,8 +427,8 @@ impl<T> StableVec<T> {
     ///
     /// # Warning
     ///
-    /// This method invalidates all indices and it does not preserve the order
-    /// of elements!
+    /// This method invalidates the indices of all elements that are stored
+    /// after the first hole and it does not preserve the order of elements!
     pub fn reordering_make_compact(&mut self) {
         if self.is_compact() {
             return;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,12 +14,14 @@ quickcheck! {
         }
 
         // Remember the number of elements before and call compact.
+        let sv_before = sv.clone();
         let n_before_compact = sv.num_elements();
         sv.compact();
 
         n_before_compact == sv.num_elements()
             && sv.is_compact()
             && (0..n_before_compact).all(|i| sv.get(i).is_some())
+            && sv_before.iter().all(|e| sv.contains(e))
     }
 
     fn from_and_extend_and_from_iter(items: Vec<u8>) -> bool {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -41,3 +41,15 @@ quickcheck! {
             && sv_a == sv_c
     }
 }
+
+#[test]
+fn compact_tiny() {
+    let mut sv = StableVec::from(&[1.0, 2.0, 3.0]);
+    assert!(sv.is_compact());
+
+    sv.remove(1);
+    assert!(!sv.is_compact());
+
+    sv.compact();
+    assert_eq!(sv.into_vec(), &[1.0, 3.0]);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,7 +8,7 @@ quickcheck! {
         let mut sv = StableVec::from(vec![0; insertions as usize]);
         for i in to_delete {
             let i = (i % insertions) as usize;
-            if sv.exists(i) {
+            if sv.has_element_at(i) {
                 sv.remove(i);
             }
         }
@@ -31,7 +31,7 @@ quickcheck! {
         let mut sv = StableVec::from(vec![0; insertions as usize]);
         for i in to_delete {
             let i = (i % insertions) as usize;
-            if sv.exists(i) {
+            if sv.has_element_at(i) {
                 sv.remove(i);
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,4 +21,23 @@ quickcheck! {
             && sv.is_compact()
             && (0..n_before_compact).all(|i| sv.get(i).is_some())
     }
+
+    fn from_and_extend_and_from_iter(items: Vec<u8>) -> bool {
+        use std::iter::FromIterator;
+
+        let iter_a = items.iter().cloned();
+        let iter_b = items.iter().cloned();
+
+        let sv_a = StableVec::from_iter(iter_a);
+        let sv_b = {
+            let mut sv = StableVec::new();
+            sv.extend(iter_b);
+            sv
+        };
+        let sv_c = StableVec::from(&items);
+
+        sv_a.num_elements() == items.len()
+            && sv_a == sv_b
+            && sv_a == sv_c
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,6 +24,31 @@ quickcheck! {
             && sv_before.iter().all(|e| sv.contains(e))
     }
 
+    fn stable_compact(insertions: u16, to_delete: Vec<u16>) -> bool {
+        let insertions = insertions + 1;
+        // Create stable vector containing `insertions` zeros. Afterwards, we
+        // remove at most half of those elements
+        let mut sv = StableVec::from(vec![0; insertions as usize]);
+        for i in to_delete {
+            let i = (i % insertions) as usize;
+            if sv.exists(i) {
+                sv.remove(i);
+            }
+        }
+
+        // Remember the number of elements before and call compact.
+        let sv_before = sv.clone();
+        let items_before: Vec<_> = sv_before.iter().cloned().collect();
+        let n_before_compact = sv.num_elements();
+        sv.stable_compact();
+
+
+        n_before_compact == sv.num_elements()
+            && sv.is_compact()
+            && (0..n_before_compact).all(|i| sv.get(i).is_some())
+            && sv == items_before
+    }
+
     fn from_and_extend_and_from_iter(items: Vec<u8>) -> bool {
         use std::iter::FromIterator;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use super::StableVec;
 
 quickcheck! {
-    fn compact(insertions: u16, to_delete: Vec<u16>) -> bool {
+    fn reordering_compact(insertions: u16, to_delete: Vec<u16>) -> bool {
         let insertions = insertions + 1;
         // Create stable vector containing `insertions` zeros. Afterwards, we
         // remove at most half of those elements
@@ -16,7 +16,7 @@ quickcheck! {
         // Remember the number of elements before and call compact.
         let sv_before = sv.clone();
         let n_before_compact = sv.num_elements();
-        sv.compact();
+        sv.reordering_make_compact();
 
         n_before_compact == sv.num_elements()
             && sv.is_compact()
@@ -24,7 +24,7 @@ quickcheck! {
             && sv_before.iter().all(|e| sv.contains(e))
     }
 
-    fn stable_compact(insertions: u16, to_delete: Vec<u16>) -> bool {
+    fn compact(insertions: u16, to_delete: Vec<u16>) -> bool {
         let insertions = insertions + 1;
         // Create stable vector containing `insertions` zeros. Afterwards, we
         // remove at most half of those elements
@@ -40,7 +40,7 @@ quickcheck! {
         let sv_before = sv.clone();
         let items_before: Vec<_> = sv_before.iter().cloned().collect();
         let n_before_compact = sv.num_elements();
-        sv.stable_compact();
+        sv.make_compact();
 
 
         n_before_compact == sv.num_elements()
@@ -77,6 +77,6 @@ fn compact_tiny() {
     sv.remove(1);
     assert!(!sv.is_compact());
 
-    sv.compact();
+    sv.make_compact();
     assert_eq!(sv.into_vec(), &[1.0, 3.0]);
 }


### PR DESCRIPTION
Closes #7 
Contains work for #3 

Bumps version to `v0.2.0` due to backwards incompatible renames. For details, see the changelog.