### PR TITLE
Pattern for making `make_compact` safe

### DIFF
--- a/src/jailed.rs
+++ b/src/jailed.rs
@@ -6,13 +6,13 @@ of the JailedStableVec.
 
 ```
 # fn main() {
-use stable_vec::jailed::Wrapper;
+use stable_vec::StableVec;
 
-let mut wrapper = Wrapper::<i32>::new();
+let mut sv = StableVec::new();
 
 for _ in 0..2 {
     {
-        let mut jailed = wrapper.jail();
+        let mut jailed = sv.jail();
         let idx1 = jailed.push(1);
         let idx2 = jailed.push(2);
         let sum = jailed[idx1] + jailed[idx2];
@@ -20,10 +20,10 @@ for _ in 0..2 {
         assert_eq!(3, sum);
     }
 
-    wrapper.make_compact();
+    sv.make_compact();
 }
 
-assert_eq!(&[2, 2], &*wrapper.into_vec());
+assert_eq!(&[2, 2], &*sv.into_vec());
 # }
 ```
 
@@ -31,10 +31,10 @@ The following will not compile, because the first borrow of `wrapper` by the cal
 
 ```compile_fail
 # fn main() {
-# use stable_vec::jailed::Wrapper;
-let mut wrapper = Wrapper::<i32>::new();
-let idx = wrapper.jail().push(5);
-wrapper.make_compact();
+# use stable_vec::StableVec;
+let mut sv = StableVec::<i32>::new();
+let idx = sv.jail().push(5);
+sv.make_compact();
 // error[E0499]: cannot borrow `wrapper` as mutable more than once at a time
 # }
 ```
@@ -45,35 +45,9 @@ use ::std;
 
 use std::marker::PhantomData;
 
-pub struct Wrapper<T>(StableVec<T>);
-
-impl<T> Wrapper<T> {
-    pub fn new() -> Self {
-        Wrapper(StableVec::new())
-    }
-
-    pub fn jail(&mut self) -> JailedStableVec<T> {
-        JailedStableVec(&mut self.0)
-    }
-
-    pub fn make_compact(&mut self) {
-        self.0.make_compact();
-    }
-
-    pub fn reordering_make_compact(&mut self) {
-        self.0.reordering_make_compact();
-    }
-
-    pub fn is_compact(&self) -> bool {
-        self.0.is_compact()
-    }
-
-    pub fn num_elements(&self) -> usize {
-        self.0.num_elements()
-    }
-
-    pub fn into_vec(self) -> Vec<T> {
-        self.0.into_vec()
+impl<T> StableVec<T> {
+    pub fn jail<'a>(&'a mut self) -> JailedStableVec<'a, T> {
+        JailedStableVec(self)
     }
 }
 

--- a/src/jailed.rs
+++ b/src/jailed.rs
@@ -1,0 +1,131 @@
+/*!
+A version of StableVec where the `make_compact` methods are
+safe. Anything that produces an Index must be called on a
+JailedStableVec, and Indexes are only valid for the lifetime
+of the JailedStableVec.
+
+```
+# fn main() {
+use stable_vec::jailed::Wrapper;
+
+let mut wrapper = Wrapper::<i32>::new();
+
+for _ in 0..2 {
+    {
+        let mut jailed = wrapper.jail();
+        let idx1 = jailed.push(1);
+        let idx2 = jailed.push(2);
+        let sum = jailed[idx1] + jailed[idx2];
+        jailed.remove(idx1);
+        assert_eq!(3, sum);
+    }
+
+    wrapper.make_compact();
+}
+
+assert_eq!(&[2, 2], &*wrapper.into_vec());
+# }
+```
+
+The following will not compile, because the first borrow of `wrapper` by the call to `jail` continues as long as `idx` is in scope, and conflicts with the call to `make_compact`:
+
+```compile_fail
+# fn main() {
+# use stable_vec::jailed::Wrapper;
+let mut wrapper = Wrapper::<i32>::new();
+let idx = wrapper.jail().push(5);
+wrapper.make_compact();
+// error[E0499]: cannot borrow `wrapper` as mutable more than once at a time
+# }
+```
+*/
+
+use super::StableVec;
+use ::std;
+
+use std::marker::PhantomData;
+
+pub struct Wrapper<T>(StableVec<T>);
+
+impl<T> Wrapper<T> {
+    pub fn new() -> Self {
+        Wrapper(StableVec::new())
+    }
+
+    pub fn jail(&mut self) -> JailedStableVec<T> {
+        JailedStableVec(&mut self.0)
+    }
+
+    pub fn make_compact(&mut self) {
+        self.0.make_compact();
+    }
+
+    pub fn reordering_make_compact(&mut self) {
+        self.0.reordering_make_compact();
+    }
+
+    pub fn is_compact(&self) -> bool {
+        self.0.is_compact()
+    }
+
+    pub fn num_elements(&self) -> usize {
+        self.0.num_elements()
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.0.into_vec()
+    }
+}
+
+pub struct JailedStableVec<'a, T: 'a>(&'a mut StableVec<T>);
+
+impl<'a, T> JailedStableVec<'a, T> {
+    pub fn push(&mut self, value: T) -> Index<'a> {
+        let idx = self.0.push(value);
+        self.index(idx)
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        self.0.pop()
+    }
+
+    pub fn remove(&mut self, idx: Index<'a>) -> Option<T> {
+        self.0.remove(idx.idx)
+    }
+
+    pub fn is_compact(&self) -> bool {
+        self.0.is_compact()
+    }
+
+    pub fn num_elements(&self) -> usize {
+        self.0.num_elements()
+    }
+
+    fn index(&self, idx: usize) -> Index<'a> {
+        Index {
+            idx,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> std::ops::Index<Index<'a>> for JailedStableVec<'a, T> {
+    type Output = T;
+
+    fn index(&self, index: Index<'a>) -> &T {
+        &self.0[index.idx]
+    }
+}
+
+impl<'a, T> std::ops::IndexMut<Index<'a>> for JailedStableVec<'a, T> {
+
+    fn index_mut(&mut self, index: Index<'a>) -> &mut T {
+        &mut self.0[index.idx]
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Index<'a> {
+    idx: usize,
+    _marker: PhantomData<&'a ()>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ use std::ptr;
 #[cfg(test)]
 mod tests;
 
+pub mod jailed;
+
 
 /// A `Vec<T>`-like collection which guarantees stable indices and features
 /// O(1) deletion of elements.


### PR DESCRIPTION
Hi @LukasKalbertodt, I saw your badge for this crate when I was reading the [reddit post](https://www.reddit.com/r/rust/comments/7cvh2w/programmieren_in_rust_a_full_lecture_on_rust_on/) and thought I'd take a look. I noticed how the `make_compact` functions break the guarantee of stable indexes, so thought I'd try and see if there was a way to use the borrow checker to keep you from calling `make_compact` if you were still holding on to an index.

This is the pattern I came up with. There's a new `Index<'a>` type, which is just a newtyped `usize` with a lifetime parameter. To do any operations that produce or use an `Index`, you have to call them on a `JailedStableVec<'a>`, which you can get by calling `.jail()` on a normal `StableVec`. The call to `.jail()` borrows the `StableVec`, as do any indexes returned by the methods on the `JailedStableVec`, and you can't call `make_compact` until all of the borrows have ended. This way all indexes will be valid. (For the most part. See the end of my doc comment on the `jailed` module for details of where it falls apart.)

Anyway, this makes things more complicated to use, and for all I know, `make_compact` may not cause that many bugs, so I can understand if you don't want to incorporate this into the library. I just thought it was a cool pattern, and wanted to share :smiley: