### PR TITLE
Port StableVec from bitvec to Vob (Vector of bits)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,9 @@ bit-vec = "0.5.0"
 
 [dev-dependencies]
 quickcheck = "0.7"
+bencher ="*"
+
+[[bench]]
+path = "benches/benchmark.rs"
+name = "benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 
 
 [dependencies]
-bit-vec = "0.5.0"
+vob = "2.0"
 
 [dev-dependencies]
 quickcheck = "0.7"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,143 @@
+#![feature(test)]
+#[macro_use]
+extern crate bencher;
+use bencher::Bencher;
+extern crate stable_vec;
+extern crate test;
+
+use stable_vec::StableVec;
+
+fn create_sv(a: &mut Bencher) {
+    a.iter(|| {
+        let mut v = Vec::new();
+        for x in 0..1000000 {
+            v.push(x);
+        }
+        let _sv = StableVec::from_vec(v);
+    });
+}
+
+fn clear(a: &mut Bencher) {
+    a.iter(|| {
+        let mut v = Vec::new();
+        for x in 0..1000000 {
+            v.push(x);
+        }
+        let mut sv = StableVec::from_vec(v);
+        sv.clear();
+    });
+}
+
+//uses next on sv with large chunks of deleted elements
+fn next_large_chunks(a: &mut Bencher) {
+    let mut v = Vec::new();
+    for x in 0..1000000 {
+        v.push(x);
+    }
+    let mut sv = StableVec::from_vec(v);
+    for x in 0..1000000 {
+        if x < 25000 || (x >= 25001 && x < 100000) {
+            sv.remove(x);
+        }
+    }
+    a.iter(|| {
+        let mut it = sv.iter();
+        assert_eq!(it.next(), Some(&25000));
+        assert_eq!(it.next(), Some(&100000));
+    });
+}
+
+//next on sv with every 5th element deleted
+fn next_5th_elem_del(a: &mut Bencher) {
+    let mut v = Vec::new();
+    for x in 0..1000000 {
+        v.push(x);
+    }
+    let mut sv = StableVec::from_vec(v);
+
+    for i in 0..1000000 {
+        if i % 5 == 0 {
+            sv.remove(i);
+        }
+    }
+
+    a.iter(|| {
+        let mut itr = sv.iter();
+        while itr.next() != None {}
+    });
+}
+
+//next on sv with all but 5th elements deleted
+fn next_only_5th(a: &mut Bencher) {
+    let mut v = Vec::new();
+    for x in 0..10000 {
+        v.push(x);
+    }
+    let mut sv = StableVec::from_vec(v);
+    for i in 0..10000 {
+        if i % 5 != 0 {
+            sv.remove(i);
+        }
+    }
+
+    a.iter(|| {
+        let mut itr = sv.iter();
+        while itr.next() != None {}
+    });
+}
+
+//next on sv with no deleted elements
+fn next_no_del(a: &mut Bencher) {
+    let mut v = Vec::new();
+    for x in 0..100000 {
+        v.push(x);
+    }
+    let sv = StableVec::from_vec(v);
+    a.iter(|| {
+        let mut itr = sv.iter();
+        while itr.next() != None {}
+    });
+}
+
+fn delete(a: &mut Bencher) {
+    let mut v = Vec::new();
+    for x in 0..10000 {
+        v.push(x);
+    }
+    let mut sv = StableVec::from_vec(v);
+    a.iter(|| {
+        for x in 0..10000 {
+            if (x >= 250 && x < 300)
+                || (x >= 400 && x < 500)
+                || (x >= 2500 && x < 3000)
+                || (x >= 4000 && x < 5000)
+                || (x >= 6000 && x < 7000)
+            {
+                sv.remove(x);
+            }
+        }
+    });
+}
+
+fn grow(a: &mut Bencher) {
+    a.iter(|| {
+        let mut v = Vec::new();
+        for x in 0..10000 {
+            v.push(x);
+        }
+        let mut sv = StableVec::from_vec(v);
+        sv.grow(10000);
+    });
+}
+benchmark_group!(
+    benches,
+    create_sv,
+    clear,
+    next_large_chunks,
+    next_5th_elem_del,
+    next_only_5th,
+    next_no_del,
+    delete,
+    grow
+);
+benchmark_main!(benches);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -7,24 +7,14 @@ extern crate test;
 
 use stable_vec::StableVec;
 
-fn create_sv(a: &mut Bencher) {
-    a.iter(|| {
-        let mut v = Vec::new();
-        for x in 0..1000000 {
-            v.push(x);
-        }
-        let _sv = StableVec::from_vec(v);
-    });
-}
-
 fn clear(a: &mut Bencher) {
+    let mut v = Vec::new();
+    for x in 0..1000000 {
+        v.push(x);
+    }
+    let sv = StableVec::from_vec(v);
     a.iter(|| {
-        let mut v = Vec::new();
-        for x in 0..1000000 {
-            v.push(x);
-        }
-        let mut sv = StableVec::from_vec(v);
-        sv.clear();
+        sv.clone().clear();
     });
 }
 
@@ -131,7 +121,6 @@ fn grow(a: &mut Bencher) {
 }
 benchmark_group!(
     benches,
-    create_sv,
     clear,
     next_large_chunks,
     next_5th_elem_del,


### PR DESCRIPTION
Vob (vector of bits) performs better than Bitvec in most cases. Using trailing_zeros, Vob can be iterated over faster than Bitvec. This speeds up iter.next() in StableVec for a Stablevec with many unset bits.
For example, when running iter.next() on a StableVec with 1000000 elements where only the 25000th element is set, the Vob implementation takes 1,521 ns/iter (+/- 123), whereas the Bitvec implementation takes 128,891 ns/iter (+/- 15,316).  When running on a StableVec with 100000 elements, the Vob implementation takes 301,771 ns/iter (+/- 17,713) whereas the bitvec implementation took 354,491 ns/iter (+/- 71,972).