### PR TITLE
Implement `size_hint` and `ExactSizeIterator` for all three iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.2] - 2019-01-07
 ### Added
 - All three iterators implement `Iterator::size_hint` and `ExactSizeIterator`
   now and report the correct length.
@@ -68,7 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Everything.
 
 
-[Unreleased]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/LukasKalbertodt/stable-vec/compare/v0.1.1...v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- All three iterators implement `Iterator::size_hint` and `ExactSizeIterator`
+  now and report the correct length.
 
 ## [0.2.1] - 2018-09-26
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-vec"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 
 description = """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -886,8 +886,8 @@ impl<T> StableVec<T> {
 
     /// Retains only the elements specified by the given predicate.
     ///
-    /// Each element `e` for which `predicate(&e)` returns `false` is removed
-    /// from the stable vector.
+    /// Each element `e` for which `should_be_kept(&e)` returns `false` is
+    /// removed from the stable vector.
     ///
     /// # Example
     ///
@@ -898,14 +898,15 @@ impl<T> StableVec<T> {
     ///
     /// assert_eq!(sv, &[2, 4] as &[_]);
     /// ```
-    pub fn retain<P>(&mut self, mut predicate: P)
+    pub fn retain<P>(&mut self, mut should_be_kept: P)
     where
         P: FnMut(&T) -> bool,
     {
-        let mut it = self.iter_mut();
-        while let Some(e) = it.next() {
-            if !predicate(e) {
-                it.remove_current();
+        let mut pos = 0;
+
+        while let Some(idx) = next_valid_index(&mut pos, &self.deleted) {
+            if !should_be_kept(&self[idx]) {
+                self.remove(idx);
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -112,3 +112,35 @@ fn insert_into_hole_and_grow() {
     assert_eq!(sv.num_elements(), 3);
     assert_eq!(sv.clone().into_vec(), &['a', 'c', 'd']);
 }
+
+#[test]
+fn size_hints() {
+    let mut sv = StableVec::<()>::new();
+
+    assert_eq!(sv.iter().size_hint(), (0, Some(0)));
+    assert_eq!(sv.iter_mut().size_hint(), (0, Some(0)));
+    assert_eq!(sv.keys().size_hint(), (0, Some(0)));
+
+
+    let mut sv = StableVec::from(&[0, 1, 2, 3, 4]);
+    sv.remove(1);
+
+    macro_rules! check_iter {
+        ($it:expr) => {{
+            let mut it = $it;
+            assert_eq!(it.size_hint(), (4, Some(4)));
+            assert!(it.next().is_some());
+            assert_eq!(it.size_hint(), (3, Some(3)));
+            assert!(it.next().is_some());
+            assert_eq!(it.size_hint(), (2, Some(2)));
+            assert!(it.next().is_some());
+            assert_eq!(it.size_hint(), (1, Some(1)));
+            assert!(it.next().is_some());
+            assert_eq!(it.size_hint(), (0, Some(0)));
+        }}
+    }
+
+    check_iter!(sv.iter());
+    check_iter!(sv.iter_mut());
+    check_iter!(sv.keys());
+}


### PR DESCRIPTION
Reporting the correct size is very useful in many situations and can lead to a significant speedup when dealing with allocations.