### PR TITLE
Use `no-std-compat` crate to simplify code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ members = ["asm-test"]
 [features]
 nightly-bench = ["criterion/real_blackbox"]
 
+[dependencies]
+no-std-compat = { version = "0.2.0", features = ["alloc"] }
+
 [dev-dependencies]
 quickcheck = "0.8"
 quickcheck_macros = "0.8"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A `Vec<T>`-like collection which guarantees stable indices and features O(1) ele
 It is semantically very similar to `Vec<Option<T>>`, but with a more optimized memory layout and a more convenient API.
 This data structure is very useful as a foundation to implement other data structures like graphs and polygon meshes.
 In those situations, `stable-vec` functions a bit like an arena memory allocator.
-This crate has no dependencies and works in `#![no_std]` context (it needs the `alloc` crate, though).
+This crate works in `#![no_std]` context (it needs the `alloc` crate, though).
 
 This crate implements different strategies to store the information.
 As these strategies have slightly different performance characteristics, the user can choose which to use.

--- a/src/core/bitvec.rs
+++ b/src/core/bitvec.rs
@@ -1,4 +1,4 @@
-use crate::std::{
+use std::{
     alloc::{alloc, alloc_zeroed, dealloc, handle_alloc_error, realloc, Layout},
     fmt,
     mem::{align_of, size_of},

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,7 +5,7 @@
 //! implementation, making the stable vector work. See [`Core`][core::Core] for
 //! more information.
 
-use crate::std::{
+use std::{
     prelude::v1::*,
     fmt,
     marker::PhantomData,

--- a/src/core/option.rs
+++ b/src/core/option.rs
@@ -1,4 +1,4 @@
-use crate::std::{
+use std::{
     prelude::v1::*,
     fmt,
     hint::unreachable_unchecked,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,7 +2,7 @@
 //!
 //! This is in its own module to not pollute the top-level namespace.
 
-use crate::std::{
+use std::{
     iter::FusedIterator,
     ops::Range,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,10 +98,6 @@
 #![deny(intra_doc_link_resolution_failure)]
 
 // ----- Deal with `no_std` stuff --------------------------------------------
-// Ideally we could use the crate `no-std-compat` for this. Unfortunately, it
-// is only usable on nightly at the moment. Once that changes, all of this will
-// be replaced.
-
 #![no_std]
 
 // Import the real `std` for tests.
@@ -109,27 +105,15 @@
 #[macro_use]
 extern crate std;
 
-// Otherwise import `core` and `alloc` and define a module `std` which
-// simulates the real `std` by reexporting the symbols from `core` and `alloc`.
-// Well, not perfectly, but all parts we need.
-#[cfg(not(test))] extern crate alloc as _alloc;
-#[cfg(not(test))] extern crate core as _core;
+// When compiling in a normal way, we use this compatibility layer that
+// reexports symbols from `core` and `alloc` under the name `std`. This is just
+// convenience so that all other imports in this crate can just use `std`.
 #[cfg(not(test))]
-mod std {
-    pub use _core::*;
-    pub use _alloc::alloc;
-
-    pub mod prelude {
-        pub mod v1 {
-            pub use _core::prelude::v1::*;
-            pub use _alloc::vec::Vec;
-        }
-    }
-}
+extern crate no_std_compat as std;
 // ---------------------------------------------------------------------------
 
 
-use crate::std::{
+use std::{
     prelude::v1::*,
     cmp,
     fmt,


### PR DESCRIPTION
This crate does exactly what I've written before. No need for me to
write it myself.