### PR TITLE
remove no-std-compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ members = ["asm-test"]
 nightly-bench = ["criterion/real_blackbox"]
 
 [dependencies]
-no-std-compat = { version = "0.2.0", features = ["alloc"] }
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/src/core/bitvec.rs
+++ b/src/core/bitvec.rs
@@ -1,8 +1,19 @@
-use std::{
-    alloc::{alloc, alloc_zeroed, dealloc, handle_alloc_error, realloc, Layout},
+use ::core::{
     fmt,
     mem::{align_of, size_of},
     ptr::{self, NonNull},
+};
+
+use alloc::{
+    //
+    alloc::{
+        alloc,
+        alloc_zeroed,
+        dealloc,
+        handle_alloc_error,
+        realloc,
+        Layout
+    }
 };
 
 use super::Core;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,8 +5,7 @@
 //! implementation, making the stable vector work. See [`Core`][core::Core] for
 //! more information.
 
-use std::{
-    prelude::v1::*,
+use ::core::{
     fmt,
     marker::PhantomData,
     ops::{Deref, DerefMut},

--- a/src/core/option.rs
+++ b/src/core/option.rs
@@ -1,9 +1,10 @@
-use std::{
-    prelude::v1::*,
+use ::core::{
     fmt,
     hint::unreachable_unchecked,
     ptr,
 };
+
+use alloc::vec::Vec;
 
 use super::Core;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,7 +2,7 @@
 //!
 //! This is in its own module to not pollute the top-level namespace.
 
-use std::{
+use ::core::{
     iter::FusedIterator,
     ops::Range,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,30 +97,20 @@
 #![deny(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)]
 
-// ----- Deal with `no_std` stuff --------------------------------------------
-#![no_std]
-
-// Import the real `std` for tests.
-#[cfg(test)]
-#[macro_use]
-extern crate std;
-
-// When compiling in a normal way, we use this compatibility layer that
-// reexports symbols from `core` and `alloc` under the name `std`. This is just
-// convenience so that all other imports in this crate can just use `std`.
-#[cfg(not(test))]
-extern crate no_std_compat as std;
-// ---------------------------------------------------------------------------
+// enable `no_std` for everything except for tests.
+#![cfg_attr(not(test), no_std)]
+extern crate alloc;
 
 
-use std::{
-    prelude::v1::*,
+use ::core::{
     cmp,
     fmt,
     iter::FromIterator,
     mem,
     ops::{Index, IndexMut},
 };
+use alloc::vec::Vec;
+
 use crate::{
     core::{Core, DefaultCore, OwningCore, OptionCore, BitVecCore},
     iter::{Indices, Iter, IterMut, IntoIter, Values, ValuesMut},


### PR DESCRIPTION
This PR removes the dependency on the `no-std-compat` crate to make this crate have zero dependencies.

There is little benefit in using the crate, because as can be seen in the diff of the PR, there are only a few lines that have to be changed to make it work without it.

On my local machine the tests failed on nightly with confusing errors like this one:
```
error: #[quickcheck] is only supported on statics and functions
    --> src/tests.rs:1162:9
     |
1162 |         fn reordering_compact(insertions: u16, to_delete: Vec<u16>) -> bool {
     |         ^^
...
1238 |     gen_tests_for!(InlineStableVec);
     |     -------------------------------- in this macro invocation
```

idk why they fail, but they work on stable.