### PR TITLE
Fix UB when calling `get()` after `clear()` for `InlineStableVec`

### DIFF
--- a/src/core/option.rs
+++ b/src/core/option.rs
@@ -162,7 +162,7 @@ impl<T> Core<T> for OptionCore<T> {
     unsafe fn has_element_at(&self, idx: usize) -> bool {
         debug_assert!(idx < self.cap());
 
-        self.data.get_unchecked(idx).is_some()
+        idx < self.len() && self.data.get_unchecked(idx).is_some()
     }
 
     unsafe fn insert_at(&mut self, idx: usize, elem: T) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -896,6 +896,7 @@ macro_rules! gen_tests_for {
             let mut sv = $ty::from_iter(vec![1, 3, 5]);
             sv.clear();
             assert_sv_eq!(sv, []: u32);
+            assert_eq!(sv.get(0), None);
         }
 
         #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -166,6 +166,7 @@ macro_rules! gen_tests_for {
 
             assert!(sv.capacity() >= 3);
             assert_sv_eq!(sv, []: String);
+            assert_eq!(sv.get(0), None);
         }
 
         #[test]


### PR DESCRIPTION
The test added here was failing, this adds manual bounds checking on `has_element_at`,
for reasons I don't yet understand this manual bounds checking is *not* equivalent to `self.data.get(idx).is_some()`,
which appears to actually just break everything.