### PR TITLE
fix warning about hidden lifetime in values_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,7 +737,7 @@ impl<T, C: Core<T>> StableVecFacade<T, C> {
     ///
     /// assert_eq!(sv, &[2.0, 4.0, 6.0] as &[_]);
     /// ```
-    pub fn values_mut(&mut self) -> ValuesMut<T, C> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, T, C> {
         ValuesMut::new(self)
     }
 


### PR DESCRIPTION
running `cargo check` on the current master with a new rust version yields the following warning:
```
    Checking stable-vec v0.4.1 (/.../stable-vec)
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/lib.rs:740:23
    |
740 |     pub fn values_mut(&mut self) -> ValuesMut<T, C> {
    |                       ^^^^^^^^^     ^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                       |
    |                       the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
740 |     pub fn values_mut(&mut self) -> ValuesMut<'_, T, C> {
    |                                               +++

warning: `stable-vec` (lib) generated 1 warning (run `cargo fix --lib -p stable-vec` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
```

fix the warning by adding the missing `'_`.